### PR TITLE
Update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,3 @@ updates:
     commit-message:
       prefix: 'deps'
     open-pull-requests-limit: 10
-  - package-ecosystem: 'yarn'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-    commit-message:
-      prefix: 'deps'
-    open-pull-requests-limit: 10


### PR DESCRIPTION
This pull request includes a change to the `.github/dependabot.yml` file to remove the configuration for the `yarn` package ecosystem, which was previously set to run weekly and limit open pull requests to 10.

Configuration changes:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L10-L16): Removed the `yarn` package ecosystem configuration, including its schedule and open pull requests limit.